### PR TITLE
 [UI 구현] 로그인 페이지

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,7 +7,7 @@ import { Metadata } from 'next';
 export const metadata: Metadata = {
   icons: {
     icon: '/favicon.ico',
-  }
+  },
 };
 
 const fontSans = Geist({

--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -1,5 +1,17 @@
+import { LoginContainer } from '@/features/auth';
+import { SimpleLogo } from '@/shared';
+import Link from 'next/link';
+
 const LoginPage = () => {
-  return <div>LoginPage</div>;
+  return (
+    <main className='w-full flex flex-col items-center h-dvh text-center justify-center gap-3 bg-[#0F1729] text-white'>
+      <SimpleLogo />
+      <LoginContainer />
+      <Link href='/signup'>
+        <p className='font-semibold text-sm'>회원가입</p>
+      </Link>
+    </main>
+  );
 };
 
 export default LoginPage;

--- a/apps/web/src/features/auth/index.ts
+++ b/apps/web/src/features/auth/index.ts
@@ -1,0 +1,1 @@
+export * from './ui';

--- a/apps/web/src/features/auth/ui/index.ts
+++ b/apps/web/src/features/auth/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './login-container';

--- a/apps/web/src/features/auth/ui/login-container.tsx
+++ b/apps/web/src/features/auth/ui/login-container.tsx
@@ -1,32 +1,39 @@
 'use client';
 
-import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+type FormData = {
+  id: string;
+  password: string;
+};
 
 export const LoginContainer = () => {
-  const [id, setId] = useState('');
-  const [password, setPassword] = useState('');
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid },
+  } = useForm<FormData>({ mode: 'onChange' });
 
-  const isDisabled = !id || !password;
+  const onSubmit = (data: FormData) => {
+    // Todo: API 요청
+  };
 
   const inputFields = [
-    { label: '아이디', type: 'text', value: id, onChange: setId },
-    { label: '비밀번호', type: 'password', value: password, onChange: setPassword },
+    { name: 'id', label: '아이디', type: 'text' },
+    { name: 'password', label: '비밀번호', type: 'password' },
   ];
-
-  // Todo: 폼 제출 - 실패 시 응답 보여주기
 
   return (
     <div className='flex flex-col gap-8 bg-white py-6 rounded-xl text-black w-96'>
       <h1 className='font-semibold px-8 text-xl'>로그인</h1>
-      <form action='' className='flex flex-col gap-8'>
+      <form onSubmit={handleSubmit(onSubmit)} className='flex flex-col gap-8'>
         <ul className='flex flex-col gap-3 px-8'>
-          {inputFields.map(({ label, type, value, onChange }) => (
-            <li key={label} className='flex flex-col gap-2 items-start'>
+          {inputFields.map(({ name, label, type }) => (
+            <li key={name} className='flex flex-col gap-2 items-start'>
               <label className='text-sm font-semibold'>{label}</label>
               <input
                 type={type}
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
+                {...register(name as keyof FormData)}
                 className='w-full text-sm py-2 px-3 rounded-lg border'
               />
             </li>
@@ -35,9 +42,9 @@ export const LoginContainer = () => {
         <div className='w-full px-8'>
           <button
             type='submit'
-            disabled={isDisabled}
-            className={`w-full font-semibold text-sm rounded-lg py-2 px-4 border
-              ${isDisabled ? 'bg-gray-200 text-gray-500 cursor-not-allowed' : 'bg-[#0F1729] text-white'}
+            disabled={!isValid}
+            className={`w-full font-semibold text-sm rounded-lg py-2 px-4 border 
+              ${!isValid ? 'bg-gray-200 text-gray-500 cursor-not-allowed' : 'bg-[#0F1729] text-white'}
             `}
           >
             로그인

--- a/apps/web/src/features/auth/ui/login-container.tsx
+++ b/apps/web/src/features/auth/ui/login-container.tsx
@@ -11,7 +11,7 @@ export const LoginContainer = () => {
   const {
     register,
     handleSubmit,
-    formState: { errors, isValid },
+    formState: { isValid },
   } = useForm<FormData>({ mode: 'onChange' });
 
   const onSubmit = (data: FormData) => {

--- a/apps/web/src/features/auth/ui/login-container.tsx
+++ b/apps/web/src/features/auth/ui/login-container.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+
+export const LoginContainer = () => {
+  const [id, setId] = useState('');
+  const [password, setPassword] = useState('');
+
+  const isDisabled = !id || !password;
+
+  // Todo: 폼 제출 - 실패 시 응답 보여주기
+
+  return (
+    <div className='flex flex-col gap-8 bg-white py-6 rounded-xl text-black w-96'>
+      <h1 className='font-semibold px-8 text-xl'>로그인</h1>
+      <form action='' className='flex flex-col gap-8'>
+        <ul className='flex flex-col gap-3 px-8'>
+          <li className='flex flex-col gap-2 items-start'>
+            <label className='text-sm font-semibold'>아이디</label>
+            <input
+              type='text'
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              className='w-full text-sm py-2 px-3 rounded-lg border'
+            />
+          </li>
+          <li className='flex flex-col gap-2 items-start'>
+            <label className='text-sm font-semibold'>비밀번호</label>
+            <input
+              type='password'
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className='w-full text-sm py-2 px-3 rounded-lg border'
+            />
+          </li>
+        </ul>
+        <div className='w-full px-8'>
+          <button
+            type='submit'
+            disabled={isDisabled}
+            className={`w-full font-semibold text-sm rounded-lg py-2 px-4 border
+              ${isDisabled ? 'bg-gray-200 text-gray-500 cursor-not-allowed' : 'bg-[#0F1729] text-white'}
+            `}
+          >
+            로그인
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/apps/web/src/features/auth/ui/login-container.tsx
+++ b/apps/web/src/features/auth/ui/login-container.tsx
@@ -33,7 +33,7 @@ export const LoginContainer = () => {
               <label className='text-sm font-semibold'>{label}</label>
               <input
                 type={type}
-                {...register(name as keyof FormData)}
+                {...register(name as keyof FormData, { required: `${label}를 입력해주세요.` })}
                 className='w-full text-sm py-2 px-3 rounded-lg border'
               />
             </li>

--- a/apps/web/src/features/auth/ui/login-container.tsx
+++ b/apps/web/src/features/auth/ui/login-container.tsx
@@ -8,6 +8,11 @@ export const LoginContainer = () => {
 
   const isDisabled = !id || !password;
 
+  const inputFields = [
+    { label: '아이디', type: 'text', value: id, onChange: setId },
+    { label: '비밀번호', type: 'password', value: password, onChange: setPassword },
+  ];
+
   // Todo: 폼 제출 - 실패 시 응답 보여주기
 
   return (
@@ -15,24 +20,17 @@ export const LoginContainer = () => {
       <h1 className='font-semibold px-8 text-xl'>로그인</h1>
       <form action='' className='flex flex-col gap-8'>
         <ul className='flex flex-col gap-3 px-8'>
-          <li className='flex flex-col gap-2 items-start'>
-            <label className='text-sm font-semibold'>아이디</label>
-            <input
-              type='text'
-              value={id}
-              onChange={(e) => setId(e.target.value)}
-              className='w-full text-sm py-2 px-3 rounded-lg border'
-            />
-          </li>
-          <li className='flex flex-col gap-2 items-start'>
-            <label className='text-sm font-semibold'>비밀번호</label>
-            <input
-              type='password'
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className='w-full text-sm py-2 px-3 rounded-lg border'
-            />
-          </li>
+          {inputFields.map(({ label, type, value, onChange }) => (
+            <li key={label} className='flex flex-col gap-2 items-start'>
+              <label className='text-sm font-semibold'>{label}</label>
+              <input
+                type={type}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className='w-full text-sm py-2 px-3 rounded-lg border'
+              />
+            </li>
+          ))}
         </ul>
         <div className='w-full px-8'>
           <button

--- a/apps/web/src/features/auth/ui/login-container.tsx
+++ b/apps/web/src/features/auth/ui/login-container.tsx
@@ -11,7 +11,7 @@ export const LoginContainer = () => {
   const {
     register,
     handleSubmit,
-    formState: { isValid },
+    formState: { isValid, errors },
   } = useForm<FormData>({ mode: 'onChange' });
 
   const onSubmit = (data: FormData) => {
@@ -36,6 +36,9 @@ export const LoginContainer = () => {
                 {...register(name as keyof FormData, { required: `${label}를 입력해주세요.` })}
                 className='w-full text-sm py-2 px-3 rounded-lg border'
               />
+              {errors[name as keyof FormData] && (
+                <p className='text-red-500 text-xs'>{errors[name as keyof FormData]?.message}</p>
+              )}
             </li>
           ))}
         </ul>

--- a/apps/web/src/features/index.ts
+++ b/apps/web/src/features/index.ts
@@ -1,1 +1,2 @@
+export * from './auth';
 export * from './main';

--- a/apps/web/src/shared/components/index.ts
+++ b/apps/web/src/shared/components/index.ts
@@ -1,2 +1,3 @@
-export * from './symbol-logo';
 export * from './auth-buttons';
+export * from './simple-logo';
+export * from './symbol-logo';

--- a/apps/web/src/shared/components/simple-logo/SimpleLogo.tsx
+++ b/apps/web/src/shared/components/simple-logo/SimpleLogo.tsx
@@ -1,0 +1,16 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export const SimpleLogo = () => {
+  return (
+    <Link href='/' className='absolute top-6'>
+      <Image
+        src='/logo/simple-logo.svg'
+        alt='haedal'
+        className='cursor-pointer'
+        width={230}
+        height={0}
+      />
+    </Link>
+  );
+};

--- a/apps/web/src/shared/components/simple-logo/index.ts
+++ b/apps/web/src/shared/components/simple-logo/index.ts
@@ -1,0 +1,1 @@
+export * from './SimpleLogo';


### PR DESCRIPTION
## 📝 상세 내용
- 큰 틀은 /login/page를 보시면 되며, 그 안의 컴포넌트들을 /features/auth에 작업하였습니다. (기존 폴더 구조에 따라 똑같이)  
- 피그마 디자인 그대로 작업하니 밸런스가 괴상해져서(???) 임의로 바꾸어 작업했습니다. 
(흰색 박스 너비도 임의로 지정 / 반응형 X )
- layout 파일은 뭘 건드려야 할지 모르겠어서 건드리지 않았어요..  
- state 대신 리액트 훅 폼의 register로 아이디, 비번 값을 관리할 수 있게 했습니다.  
- 이미 nextjs로 작업화고 있었어서 새 레포가 아닌 기존 레포에 PR 올립니닷 
머지하고 나서 옮기겠습니다.  

## #️⃣ 이슈 번호
- closes #19 

## 💬 리뷰 요구사항
로그인 페이지는 아이디, 비번 값이 없을 때 버튼을 비활성화했고, 리액트 훅 폼으로 유효성 검사도 하고 있어서  
zod가 필요한가 싶네요   
(아이디 몇 자 이상, 비번 몇 자 이상 <- 굳이..)  

## ⏰ 현재 버그
X

## 📷 스크린샷(선택)
![image](https://github.com/user-attachments/assets/5bfdd8a8-42fb-43c2-8ee0-624f24573eca)

## 🔗 참고 자료(선택)

